### PR TITLE
Fix container not showing version number + min size of .01MB for output files with data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ RUN python3 -m playwright install-deps chromium \
 # --- App code ---
 COPY bin ./bin
 COPY templates ./templates
+COPY VERSION .
 # COPY static ./static
 
 # Ensure runtime dirs exist

--- a/templates/adb_config.html
+++ b/templates/adb_config.html
@@ -487,7 +487,7 @@ let html = '';
 if (globalFiles.length > 0) {
 html += '<div style="margin-bottom: 20px;"><h3 style="font-size: 16px; margin-bottom: 12px; color: #fbbf24;">📦 Combined (All Providers)</h3><ul style="list-style: none; padding: 0;">';
 globalFiles.forEach(([name, info]) => {
-const sizeMB = (info.size / 1024 / 1024).toFixed(2);
+const sizeMB = (info.size > 0 ? Math.max(0.01, info.size / 1024 / 1024) : 0).toFixed(2);
 html += `
 <li style="padding: 10px; background: #0f172a; border-radius: 6px; margin-bottom: 6px; display: flex; justify-content: space-between; align-items: center;">
 <a href="/out/${name}" style="color: #60a5fa; text-decoration: none; font-family: monospace; font-size: 13px;">${name}</a>
@@ -505,7 +505,7 @@ providers.forEach(provider => {
 const files = fileGroups[provider];
 html += `<div style="margin-bottom: 16px;"><h3 style="font-size: 15px; margin-bottom: 8px; color: #60a5fa;">📺 ${provider.toUpperCase()}</h3><ul style="list-style: none; padding: 0;">`;
 files.forEach(([name, info]) => {
-const sizeMB = (info.size / 1024 / 1024).toFixed(2);
+const sizeMB = (info.size > 0 ? Math.max(0.01, info.size / 1024 / 1024) : 0).toFixed(2);
 html += `
 <li style="padding: 8px; background: #0f172a; border-radius: 6px; margin-bottom: 4px; display: flex; justify-content: space-between; align-items: center;">
 <a href="/out/${name}" style="color: #60a5fa; text-decoration: none; font-family: monospace; font-size: 12px;">${name}</a>

--- a/templates/admin_dashboard.html
+++ b/templates/admin_dashboard.html
@@ -418,7 +418,7 @@ fileList.innerHTML = '<p class="stat-value">No files generated yet</p>';
 fileList.innerHTML = '<ul class="file-list">' + files.map(([name, info]) => `
 <li class="file-item">
 <a href="/out/${name}" class="file-name">${name}</a>
-<span class="file-size">${(info.size / 1024 / 1024).toFixed(2)} MB</span>
+<span class="file-size">${(info.size > 0 ? Math.max(0.01, info.size / 1024 / 1024) : 0).toFixed(2)} MB</span>
 </li>
 `).join('') + '</ul>';
 }


### PR DESCRIPTION
The Dockerfile didn't copy VERSION so it was defaulting to 0.1.0. Also, "Output Files" that contained data, but were small, were showing 0.00 MB -- so I've changed this so that any file that contains some data will show at least 0.01 MB.